### PR TITLE
Выбор способа получения инстанса файла

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ class Document extends ActiveRecord
             [
                 'class' => UploadBehavior::className(),
                 'attribute' => 'file',
+                'instanceByName' => false,
                 'scenarios' => ['insert', 'update'],
                 'path' => '@webroot/upload/docs',
                 'url' => '@web/upload/docs',

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ class Document extends ActiveRecord
             [
                 'class' => UploadBehavior::className(),
                 'attribute' => 'file',
-                'instanceByName' => false,
                 'scenarios' => ['insert', 'update'],
                 'path' => '@webroot/upload/docs',
                 'url' => '@web/upload/docs',
@@ -137,4 +136,27 @@ Example view file:
         <?= Html::submitButton('Submit', ['class' => 'btn btn-primary']) ?>
     </div>
 <?php ActiveForm::end(); ?>
+```
+
+### RESTfull
+
+If you use UploadBehavior in RESTfull application and you do not need a prefix of the model name, set the property `instanceByName = false`:
+
+```php
+/**
+ * @inheritdoc
+ */
+function behaviors()
+{
+    return [
+        [
+            'class' => UploadBehavior::className(),
+            'attribute' => 'file',
+            'instanceByName' => true,
+            'scenarios' => ['insert', 'update'],
+            'path' => '@webroot/upload/docs',
+            'url' => '@web/upload/docs',
+        ],
+    ];
+}
 ```

--- a/UploadBehavior.php
+++ b/UploadBehavior.php
@@ -60,6 +60,10 @@ class UploadBehavior extends Behavior
      */
     public $url;
     /**
+     * @var bool Getting file instance by name
+     */
+    public $instanceByName = false;
+    /**
      * @var boolean|callable generate a new unique name for the file
      * set true or anonymous function takes the old filename and returns a new name.
      * @see self::generateFileName()
@@ -121,7 +125,11 @@ class UploadBehavior extends Behavior
         /** @var BaseActiveRecord $model */
         $model = $this->owner;
         if (in_array($model->scenario, $this->scenarios)) {
-            $this->_file = UploadedFile::getInstance($model, $this->attribute);
+            if ($this->instanceByName === true) {
+                $this->_file = UploadedFile::getInstanceByName($this->attribute);
+            } else {
+                $this->_file = UploadedFile::getInstance($model, $this->attribute);
+            }
             if ($this->_file instanceof UploadedFile) {
                 $this->_file->name = $this->getFileName($this->_file);
                 $model->setAttribute($this->attribute, $this->_file);


### PR DESCRIPTION
Если из обычной формы приходит файл в поле с названием вида `Model[file]`, то в REST-приложении от клиента приходит поле с файлом без префикса, т. е. просто `file`. Добавил свойство, что бы в настройках поведения можно было указывать способ получения инстанса.